### PR TITLE
Fixed formatting for non US locale

### DIFF
--- a/src/main/java/com/machinezoo/sourceafis/visualization/svg/SvgRounding.java
+++ b/src/main/java/com/machinezoo/sourceafis/visualization/svg/SvgRounding.java
@@ -1,18 +1,20 @@
 // Part of SourceAFIS Visualization: https://sourceafis.machinezoo.com/transparency/
 package com.machinezoo.sourceafis.visualization.svg;
 
+import java.util.Locale;
+
 /*
  * Limit number of digits produced into SVG. Screens cannot display smaller differences anyway.
  * Some SVG viewers don't support more than 2 decimal places anyway.
  */
 public class SvgRounding {
 	public static String position(double x) {
-		return String.format("%.2f", x);
+		return String.format(Locale.US,"%.2f", x);
 	}
 	public static String angle(double x) {
 		/*
 		 * 1% of one degree is accurate enough for small markers.
 		 */
-		return String.format("%.2f", x);
+		return String.format(Locale.US, "%.2f", x);
 	}
 }


### PR DESCRIPTION
This is a problem on systems where comma "," is used as separator instead of dot "."
Which would create invalid svg transforms:
 ```xml
<g transform="translate(251,50 291,50) rotate(70,31)">
  ```